### PR TITLE
Configure asdf-lean plugin to work with lean3 and lean4

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,6 +22,27 @@ fail() {
   exit 1
 }
 
+uncompress() {
+  local ext=$1
+
+  case "$ext" in
+    zip)
+      unzip -q "$source_path" -d "$install_path" || fail "Could not uncompress $source_path"
+      cd "$extracted_path"
+      mv ./* ../ && cd ..
+      rm -rf "$source_path" "$extracted_path"
+      ;;
+    tar.gz)
+      tar zxf "$source_path" -C "$install_path" --strip-components=1 || fail "Could not uncompress $source_path"
+      rm -rf "$source_path"
+      ;;
+    tar.zst)
+      tar --zstd -xvf "$source_path" -C "$install_path" --strip-components=1 || fail "Could not uncompress $source_path"
+      rm -rf "$source_path"
+      ;;
+  esac
+}
+
 install_lean() {
   local install_type=$1
   local version=$2
@@ -33,33 +54,38 @@ install_lean() {
 
   local platform
   local extension
+  local download_url
 
   case "$OSTYPE" in
-    darwin*) platform="darwin" extension="zip" ;;
-    linux*) platform="linux" extension="tar.gz" ;;
+    darwin*) platform="darwin"
+      extension="zip"
+      ;;
+    linux*) platform="linux"
+      if [[ $version == 3* ]]; then
+        extension="tar.gz"
+      elif [[ $version == 4* ]]; then
+        extension="tar.zst"
+      fi
+      ;;
     *) fail "Unsupported platform" ;;
   esac
 
   local fullname="lean-${version}-${platform}"
-  local download_url="https://github.com/leanprover/lean/releases/download/v${version}/${fullname}.${extension}"
+
+  if [[ $version == 3* ]]; then
+    download_url="https://github.com/leanprover/lean3/releases/download/v${version}/${fullname}.${extension}"
+  elif [[ $version == 4* ]]; then
+    download_url="https://github.com/leanprover/lean4/releases/download/v${version}/${fullname}.${extension}"
+  fi
+
   local source_path="${install_path}/${fullname}.${extension}"
   local extracted_path="${install_path}/${fullname}"
 
   (
     echo "∗ Downloading and installing lean..."
+    echo $download_url
     curl --silent --location --create-dirs --output "$source_path" "$download_url" || fail "Could not download"
-    case "$platform" in
-      darwin)
-        unzip -q "$source_path" -d "$install_path" || fail "Could not uncompress"
-        cd "$extracted_path"
-        mv ./* ../ && cd ..
-        rm -rf "$source_path" "$extracted_path"
-        ;;
-      linux)
-        tar zxf "$source_path" -C "$install_path" --strip-components=1 || fail "Could not uncompress"
-        rm -rf "$source_path"
-        ;;
-    esac
+    uncompress $extension
     echo "The installation was successful!"
   ) || (
     rm -rf "$install_path"

--- a/bin/list-all
+++ b/bin/list-all
@@ -18,7 +18,8 @@
 set -eo pipefail
 
 cmd="curl --silent --location"
-releases_path="https://api.github.com/repos/leanprover/lean/releases"
+lean3_releases_path="https://api.github.com/repos/leanprover/lean3/releases"
+lean4_releases_path="https://api.github.com/repos/leanprover/lean4/releases"
 
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd --header 'Authorization: token $GITHUB_API_TOKEN'"
@@ -29,6 +30,7 @@ sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval "$cmd $releases_path" | grep 'tag_name' | sed -e '/popl_paris/d' -e 's/.* "v//;s/",//' | sort_versions | xargs)
+lean3_versions=$(eval "$cmd $lean3_releases_path" | grep 'tag_name' | sed -e '/popl_paris/d' -e 's/.* "v//;s/",//' | sort_versions | xargs)
+lean4_versions=$(eval "$cmd $lean4_releases_path" | grep 'tag_name' | sed -e '/popl_paris/d' -e 's/.* "v//;s/",//' | sort_versions | xargs)
 
-echo "$versions"
+echo "$lean3_versions $lean4_versions"


### PR DESCRIPTION
Lean version 4 onwards has a different github repository - https://github.com/leanprover/lean4/

The current asdf-plugin only works with the older repository, which has been archived and moved to https://api.github.com/repos/leanprover/lean3/

This change allows a user to interoperate between the two different versions of lean using the same plugin